### PR TITLE
Added vue engine support

### DIFF
--- a/backend/convertors/vue-converter.js
+++ b/backend/convertors/vue-converter.js
@@ -1,0 +1,269 @@
+const fs = require('fs');
+
+// Simple Vue template to HTML converter
+function vueToHtml(vueTemplate, context = {}) {
+  // Replace Vue expressions with actual values
+  let html = vueTemplate;
+  
+  // Handle Vue interpolation syntax {{ variable }}
+  html = html.replace(/\{\{\s*([^}]+)\s*\}\}/g, (match, expr) => {
+    try {
+      // Create a function that evaluates the expression with the context
+      const func = new Function(...Object.keys(context), `return ${expr.trim()}`);
+      const result = func(...Object.values(context));
+      
+      // Handle arrays (for v-for operations)
+      if (Array.isArray(result)) {
+        return result.join('');
+      }
+      
+      return result !== undefined ? result : '';
+    } catch (e) {
+      console.warn(`Error evaluating expression: ${expr}`, e);
+      return '';
+    }
+  });
+  
+  return html;
+}
+
+// Enhanced version that handles more complex Vue template expressions
+function advancedVueToHtml(vueTemplate, context = {}) {
+  // Pre-process common Vue patterns
+  let processed = vueTemplate;
+  
+  // Handle v-for directive: <li v-for="item in items">{{ item }}</li>
+  processed = processed.replace(
+    /<(\w+)([^>]*?)\s+v-for\s*=\s*["']([^"']+)\s+in\s+([^"']+)["']([^>]*?)>([\s\S]*?)<\/\1>/g,
+    (match, tagName, beforeAttrs, itemVar, arrayExpr, afterAttrs, content) => {
+      try {
+        // Get the array from context
+        const getArrayFunc = new Function(...Object.keys(context), `return ${arrayExpr.trim()};`);
+        const array = getArrayFunc(...Object.values(context));
+        
+        if (!Array.isArray(array)) return '';
+        
+        return array.map(item => {
+          // Create a new context that includes the loop variable
+          const loopContext = { ...context, [itemVar.trim()]: item };
+          
+          // Process the content with the loop context
+          let itemContent = content;
+          itemContent = itemContent.replace(/\{\{\s*([^}]+)\s*\}\}/g, (innerMatch, expr) => {
+            try {
+              const evalFunc = new Function(...Object.keys(loopContext), `return ${expr.trim()};`);
+              return evalFunc(...Object.values(loopContext));
+            } catch (e) {
+              console.warn('Error in loop expression:', expr, e);
+              return '';
+            }
+          });
+          
+          return `<${tagName}${beforeAttrs}${afterAttrs}>${itemContent}</${tagName}>`;
+        }).join('');
+      } catch (e) {
+        console.warn(`Error in v-for operation: ${match}`, e);
+        return '';
+      }
+    }
+  );
+  
+  // Handle v-if directive: <div v-if="condition">content</div>
+  processed = processed.replace(
+    /<(\w+)([^>]*?)\s+v-if\s*=\s*["']([^"']+)["']([^>]*?)>([\s\S]*?)<\/\1>/g,
+    (match, tagName, beforeAttrs, condition, afterAttrs, content) => {
+      try {
+        const func = new Function(...Object.keys(context), `
+          return (${condition.trim()}) ? \`<${tagName}${beforeAttrs}${afterAttrs}>${content}</${tagName}>\` : '';
+        `);
+        return func(...Object.values(context));
+      } catch (e) {
+        console.warn(`Error in v-if: ${match}`, e);
+        return '';
+      }
+    }
+  );
+  
+  // Handle v-show directive: <div v-show="condition">content</div>
+  processed = processed.replace(
+    /<(\w+)([^>]*?)\s+v-show\s*=\s*["']([^"']+)["']([^>]*?)>([\s\S]*?)<\/\1>/g,
+    (match, tagName, beforeAttrs, condition, afterAttrs, content) => {
+      try {
+        const func = new Function(...Object.keys(context), `
+          const shouldShow = ${condition.trim()};
+          const style = shouldShow ? '' : ' style="display: none;"';
+          return \`<${tagName}${beforeAttrs}${afterAttrs}\${style}>${content}</${tagName}>\`;
+        `);
+        return func(...Object.values(context));
+      } catch (e) {
+        console.warn(`Error in v-show: ${match}`, e);
+        return '';
+      }
+    }
+  );
+  
+  // Handle v-bind:class or :class directive
+  processed = processed.replace(
+    /\s+(?:v-bind:class|:class)\s*=\s*["']([^"']+)["']/g,
+    (match, classExpr) => {
+      try {
+        const func = new Function(...Object.keys(context), `
+          const result = ${classExpr.trim()};
+          if (typeof result === 'object' && result !== null) {
+            // Handle object syntax: { 'class-name': condition }
+            return ' class="' + Object.keys(result).filter(key => result[key]).join(' ') + '"';
+          } else if (Array.isArray(result)) {
+            // Handle array syntax: ['class1', 'class2']
+            return ' class="' + result.join(' ') + '"';
+          } else {
+            // Handle string
+            return ' class="' + result + '"';
+          }
+        `);
+        return func(...Object.values(context));
+      } catch (e) {
+        console.warn(`Error in :class binding: ${match}`, e);
+        return ' class=""';
+      }
+    }
+  );
+  
+  // Handle v-bind:style or :style directive
+  processed = processed.replace(
+    /\s+(?:v-bind:style|:style)\s*=\s*["']([^"']+)["']/g,
+    (match, styleExpr) => {
+      try {
+        const func = new Function(...Object.keys(context), `
+          const result = ${styleExpr.trim()};
+          if (typeof result === 'object' && result !== null) {
+            // Handle object syntax: { 'color': 'red', 'font-size': '14px' }
+            return ' style="' + Object.keys(result).map(key => 
+              key.replace(/([A-Z])/g, '-$1').toLowerCase() + ': ' + result[key]
+            ).join('; ') + '"';
+          } else {
+            // Handle string
+            return ' style="' + result + '"';
+          }
+        `);
+        return func(...Object.values(context));
+      } catch (e) {
+        console.warn(`Error in :style binding: ${match}`, e);
+        return ' style=""';
+      }
+    }
+  );
+  
+  // Handle remaining Vue interpolations {{ expression }}
+  processed = processed.replace(/\{\{\s*([^}]+)\s*\}\}/g, (match, expr) => {
+    try {
+      const func = new Function(...Object.keys(context), `return ${expr.trim()}`);
+      const result = func(...Object.values(context));
+      return result !== undefined ? result : '';
+    } catch (e) {
+      console.warn(`Error evaluating: ${expr}`, e);
+      return '';
+    }
+  });
+  
+  // Clean up any remaining Vue directives that weren't handled
+  processed = processed.replace(/\s+v-[a-zA-Z-]+\s*=\s*["'][^"']*["']/g, '');
+  
+  return processed;
+}
+
+// CLI interface
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  
+  if (args[0] === 'test') {
+    test();
+    process.exit(0);
+  }
+  
+  if (args.length < 2) {
+    console.log('Usage: node vue-converter.js <vue-template-string> <context-json>');
+    console.log('       node vue-converter.js test');
+    console.log('Example: node vue-converter.js "<div>{{ name }}</div>" \'{"name":"John"}\'');
+    process.exit(1);
+  }
+  
+  const vueTemplate = args[0];
+  const context = JSON.parse(args[1] || '{}');
+  
+  const html = advancedVueToHtml(vueTemplate, context);
+  console.log(html);
+}
+
+// Test the converter
+function test() {
+    const vueTemplate = `
+        <div class="invoice">
+            <h1>Invoice</h1>
+            <div v-if="showHeader" class="header">
+                <p>Company: {{ company.name }}</p>
+                <p>Address: {{ company.address }}</p>
+            </div>
+            
+            <table class="line-items">
+                <thead>
+                    <tr>
+                        <th>Item</th>
+                        <th>Description</th>
+                        <th>Quantity</th>
+                        <th>Price</th>
+                        <th>Tax</th>
+                        <th>Total</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr v-for="lineItem in lineItems">
+                        <td>{{ lineItem.item }}</td>
+                        <td>{{ lineItem.description }}</td>
+                        <td>{{ lineItem.quantity }}</td>
+                        <td>{{ lineItem.price }}</td>
+                        <td>{{ lineItem.tax }}</td>
+                        <td>{{ lineItem.total }}</td>
+                    </tr>
+                </tbody>
+            </table>
+            
+            <div class="total" v-show="showTotal">
+                <p>Grand Total: {{ grandTotal }}</p>
+            </div>
+        </div>
+    `;
+
+    const context = {
+        showHeader: true,
+        showTotal: true,
+        company: {
+            name: "Acme Corp",
+            address: "123 Main St, Anytown USA"
+        },
+        grandTotal: "$1,219.00",
+        lineItems: [
+            {
+                tax: "6%",
+                item: "Surf Board",
+                price: "$1,000",
+                total: "$1,060.00",
+                quantity: "1",
+                description: "Rides big waves"
+            },
+            {
+                tax: "6%",
+                item: "Board Wax",
+                price: "$75",
+                total: "$159.00",
+                quantity: "2",
+                description: "Best wax in town"
+            }
+        ]
+    };
+
+    console.log(advancedVueToHtml(vueTemplate, context));
+}
+
+// Test function is now accessible via the CLI
+
+module.exports = { vueToHtml, advancedVueToHtml };

--- a/backend/convertors/wrappers.py
+++ b/backend/convertors/wrappers.py
@@ -39,3 +39,40 @@ class JSXConverter:
             raise Exception(f"JSX conversion failed: {e.stderr}")
         except FileNotFoundError:
             raise Exception("Node.js not found. Please install Node.js")
+
+
+class VueConverter:
+    def __init__(self, node_script_path="convertors/vue-converter.js"):
+        self.node_script_path = node_script_path
+        
+    def convert(self, vue_string:str, context:dict=None):
+        """
+        Convert Vue string to HTML using Node.js
+        
+        Args:
+            vue_string (str): Vue template string
+            context (dict): Variables to pass to the Vue template
+            
+        Returns:
+            str: Converted HTML string
+        """
+        if context is None:
+            context = {}
+            
+        try:
+            context_json = json.dumps(context)
+            
+            # Call Node.js script
+            result = subprocess.run([
+                'node', 
+                self.node_script_path, 
+                vue_string,
+                context_json
+            ], capture_output=True, text=True, check=True)
+            
+            return result.stdout.strip()
+            
+        except subprocess.CalledProcessError as e:
+            raise Exception(f"Vue conversion failed: {e.stderr}")
+        except FileNotFoundError:
+            raise Exception("Node.js not found. Please install Node.js")

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -152,13 +152,15 @@ async def generate_pdf(
                 
             pdf_request.content = template.content
             pdf_request.is_jsx = template.engine == schemas.TemplatingEngineEnum.JSX
+            pdf_request.is_vue = template.engine == schemas.TemplatingEngineEnum.VUE
             pdf_request.data = template.data
 
         playwright_manager = await PlaywrightManager.get_instance()
         pdf_bytes = await playwright_manager.generate_pdf(
             content=pdf_request.content,
             context=pdf_request.data,
-            is_jsx=pdf_request.is_jsx
+            is_jsx=pdf_request.is_jsx,
+            is_vue=pdf_request.is_vue
         )
         
         return Response(

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -72,6 +72,7 @@ class PDFRequest(BaseModel):
     template_id: Optional[str] = None
     content: Optional[str] = None
     is_jsx: Optional[bool] = None  # Default to false for backward compatibility
+    is_vue: Optional[bool] = None  # Default to false for backward compatibility
     data: Optional[dict] = None
 
 class GuestUserResponse(BaseModel):

--- a/backend/utils/playwright_manager.py
+++ b/backend/utils/playwright_manager.py
@@ -1,7 +1,7 @@
 from playwright.async_api import async_playwright
 from typing import Optional
 import asyncio
-from convertors.wrappers import JSXConverter
+from convertors.wrappers import JSXConverter, VueConverter
 
 class PlaywrightManager:
     _instance = None
@@ -28,11 +28,12 @@ class PlaywrightManager:
             )
             self._initialized = True
 
-    def _prepare_html_content(self, content: str, context: dict = None, is_jsx: bool = False) -> str:
+    def _prepare_html_content(self, content: str, context: dict = None, is_jsx: bool = False, is_vue: bool = False) -> str:
         # Convert JSX to HTML if needed
-        is_jsx = True
         if is_jsx:
             content = JSXConverter().convert(content, context)
+        elif is_vue:
+            content = VueConverter().convert(content, context)
 
         # Wrap content with proper HTML structure and Tailwind
         return f"""
@@ -52,13 +53,13 @@ class PlaywrightManager:
         </html>
         """
 
-    async def generate_pdf(self, content: str, context: dict = None, is_jsx: bool = False) -> bytes:
+    async def generate_pdf(self, content: str, context: dict = None, is_jsx: bool = False, is_vue: bool = False) -> bytes:
         if not self._initialized:
             await self.initialize()
             
         page = await self._browser.new_page()
         try:
-            html_content = self._prepare_html_content(content, context, is_jsx)
+            html_content = self._prepare_html_content(content, context, is_jsx, is_vue)
             await page.set_content(html_content)
             # Wait for Tailwind to initialize
             await page.wait_for_load_state("networkidle")

--- a/frontend/src/views/TemplateView.vue
+++ b/frontend/src/views/TemplateView.vue
@@ -14,6 +14,7 @@ const pdfPreviewRef = ref(null)
 const isLoading = ref(false)
 const code = ref('')
 const data = ref('{\n  // Add your template data here\n}')
+const engine = ref('html')
 
 const { showSuccess, showError, showWarning } = useToast()
 
@@ -23,7 +24,7 @@ const getCurrentTemplate = async() => {
     const response = await getTemplate(templateId)
     code.value = response.content
     data.value = response.data ? JSON.stringify(response.data, null, 2) : '{\n  // Add your template data here\n}'
-
+    engine.value = response.engine
     // Only show success message if this is a retry/refresh, not on initial load
     console.log('Template loaded successfully')
   } catch (error) {
@@ -87,7 +88,7 @@ onMounted(() => {
             <p class="text-sm text-base-content/60">Edit your template code and data</p>
           </div>
           <div class="flex items-center space-x-2">
-            <div class="badge badge-primary">JSX</div>
+            <div class="badge badge-primary">{{ engine }}</div>
             <AppButton @click="saveTemplate" :isLoading="isLoading" size="sm">
               <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3-3m0 0l-3 3m3-3v12" />
@@ -102,7 +103,7 @@ onMounted(() => {
         <CodeEditor
           v-model:content="code"
           v-model:data="data"
-          :engine="'jsx'"
+          :engine="engine"
           class="h-full"
         />
       </div>


### PR DESCRIPTION
## Summary by Sourcery

Add end-to-end support for Vue templates in the PDF generation workflow by implementing a VueConverter script, wiring is_vue flags through backend schemas and routes, extending PlaywrightManager, and updating the frontend to handle dynamic engine selection.

New Features:
- Introduce VueConverter class and Node.js vue-converter.js script to convert Vue templates to HTML
- Support is_vue flag in PlaywrightManager to enable Vue-based PDF generation alongside JSX
- Extend backend PDFRequest schema and generate_pdf route to include is_vue attribute
- Update TemplateView.vue to dynamically display and pass the selected templating engine (Vue/JSX)